### PR TITLE
MAINT-43843: Use tomcat bundle 8.5.65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.resolver>2.2.5</version.shrinkwrap.resolver>
     <!-- Servers -->
-    <org.apache.tomcat.version>8.5.55</org.apache.tomcat.version>
+    <org.apache.tomcat.version>8.5.65</org.apache.tomcat.version>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Upgrade tomcat version to 8.5.65 to include security patches﻿