### PR TITLE
Security Dependencies Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- **************************************** -->
     <!-- Dependencies Versions                    -->
     <!-- **************************************** -->
-    <ch.qas.logback.version>1.1.2</ch.qas.logback.version>
     <com.google.code.guice.version>3.0</com.google.code.guice.version>
     <com.google.guava.version>20.0</com.google.guava.version>
     <com.google.javascript.version>v20170910</com.google.javascript.version>
@@ -71,10 +70,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <dom4j.version>1.6.1</dom4j.version>
+    <dom4j.version>2.1.3</dom4j.version>
     <ecs.version>1.4.2</ecs.version>
     <!-- LOGBACK implementation to use to manage logs -->
-    <ch.qas.logback.version>1.1.2</ch.qas.logback.version>
+    <ch.qas.logback.version>1.2.3</ch.qas.logback.version>
     <!-- Additional LOGBACK dependencies -->
     <org.codehaus.janino.version>2.6.1</org.codehaus.janino.version>
     <org.fusesource.jansi.version>1.11</org.fusesource.jansi.version>
@@ -121,7 +120,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.apache.ws.commons.version>1.0.1</org.apache.ws.commons.version>
     <org.artofsolving.jodconverter.version>3.0-eXo03</org.artofsolving.jodconverter.version>
     <org.aspectj.version>1.8.8</org.aspectj.version>
-    <org.bouncycastle.version>1.45</org.bouncycastle.version>
+    <org.bouncycastle.version>1.67</org.bouncycastle.version>
     <org.chromattic.version>1.3.0</org.chromattic.version>
     <org.codehaus.cargo.version>0.9</org.codehaus.cargo.version>
     <org.codehaus.groovy.version>2.4.12</org.codehaus.groovy.version>
@@ -414,7 +413,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
          <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>dom4j</groupId>
+        <groupId>org.dom4j</groupId>
         <artifactId>dom4j</artifactId>
         <version>${dom4j.version}</version>
       </dependency>
@@ -725,14 +724,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <groupId>commons-logging</groupId>
           </exclusion>
           <exclusion>
-            <artifactId>bcmail-jdk15on</artifactId>
-            <groupId>org.bouncycastle</groupId>
-          </exclusion>
-          <exclusion>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <groupId>org.bouncycastle</groupId>
-          </exclusion>
-          <exclusion>
             <artifactId>jaxb-runtime</artifactId>
             <groupId>org.glassfish.jaxb</groupId>
           </exclusion>
@@ -804,17 +795,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcmail-jdk15</artifactId>
-        <version>${org.bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15</artifactId>
-        <version>${org.bouncycastle.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bctsp-jdk15</artifactId>
+        <artifactId>bcprov-jdk15on</artifactId>
         <version>${org.bouncycastle.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Update security versions :
- ch.qos.logback:logback-classic from 1.1.2 to 1.2.3
- dom4j:dom4j:1.6.1 to org.dom4j:dom4j:2.1.3

Remove dependencies on
- org.bouncycastle:bcprov-jdk15:1.45
- org.bouncycastle:bcmail-jdk15:1.45
- org.bouncycastle:bctsp-jdk15:1.45
In eXo, we do not need theses dependencies.
bcprov and bcmail are bring by tika-parsers dependency in version 1.67
bctsp is no more needed