### PR TITLE
Downgrade ch.qos version from 1.1.11 to 1.1.9 (#50)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <dom4j.version>2.1.3</dom4j.version>
     <ecs.version>1.4.2</ecs.version>
     <!-- LOGBACK implementation to use to manage logs -->
-    <ch.qas.logback.version>1.1.11</ch.qas.logback.version>
+    <ch.qas.logback.version>1.1.9</ch.qas.logback.version>
     <!-- Additional LOGBACK dependencies -->
     <org.codehaus.janino.version>2.6.1</org.codehaus.janino.version>
     <org.fusesource.jansi.version>1.11</org.fusesource.jansi.version>


### PR DESCRIPTION
Before this fix, the server does not start.
This fix downgrade this library to a version which should works.