### PR TITLE
TASK-53062 Upgrade Hibernate library to version 5.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -936,6 +936,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${org.hibernate.hibernate-core.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -946,6 +952,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
         <version>${org.hibernate.hibernate-entitymanager.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.spec.javax.transaction</groupId>
+            <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.hibernate.common.hibernate-commons-annotations.version>5.1.2.Final</org.hibernate.common.hibernate-commons-annotations.version>
     <org.hibernate.hibernate-core.version>5.6.3.Final</org.hibernate.hibernate-core.version>
     <org.hibernate.hibernate-entitymanager.version>5.6.3.Final</org.hibernate.hibernate-entitymanager.version>
-    <org.hibernate.hibernate-validator.version>4.2.0.Final</org.hibernate.hibernate-validator.version>
     <org.hsqldb.version>2.4.0</org.hsqldb.version>
     <org.icepdf.version>5.1.1</org.icepdf.version>
     <org.imgscalr.version>4.2</org.imgscalr.version>
@@ -958,11 +957,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.hibernate</groupId>
-        <artifactId>hibernate-validator</artifactId>
-        <version>${org.hibernate.hibernate-validator.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1266,21 +1266,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </dependency>
       <dependency>
         <groupId>org.picketlink.idm</groupId>
-        <artifactId>picketlink-idm-hibernate</artifactId>
-        <version>${org.picketlink.idm.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>javax.xml.stream</groupId>
-            <artifactId>stax-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.picketlink.idm</groupId>
         <artifactId>picketlink-idm-ldap</artifactId>
         <version>${org.picketlink.idm.version}</version>
         <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.cometd.version>3.0.8</org.cometd.version>
     <org.exoplatform.framework.junit.version>1.2.4-GA</org.exoplatform.framework.junit.version>
     <org.hamcrest.version>1.3</org.hamcrest.version>
-    <org.hibernate.common.hibernate-commons-annotations.version>4.0.5.Final</org.hibernate.common.hibernate-commons-annotations.version>
-    <org.hibernate.hibernate-core.version>4.2.21.Final</org.hibernate.hibernate-core.version>
-    <org.hibernate.hibernate-entitymanager.version>4.2.21.Final</org.hibernate.hibernate-entitymanager.version>
+    <org.hibernate.common.hibernate-commons-annotations.version>5.1.2.Final</org.hibernate.common.hibernate-commons-annotations.version>
+    <org.hibernate.hibernate-core.version>5.6.3.Final</org.hibernate.hibernate-core.version>
+    <org.hibernate.hibernate-entitymanager.version>5.6.3.Final</org.hibernate.hibernate-entitymanager.version>
     <org.hibernate.hibernate-validator.version>4.2.0.Final</org.hibernate.hibernate-validator.version>
     <org.hsqldb.version>2.4.0</org.hsqldb.version>
     <org.icepdf.version>5.1.1</org.icepdf.version>
@@ -956,6 +956,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>org.hibernate.common</groupId>
         <artifactId>hibernate-commons-annotations</artifactId>
         <version>${org.hibernate.common.hibernate-commons-annotations.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>xml-apis</artifactId>
+            <groupId>xml-apis</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.hsqldb</groupId>
@@ -1283,6 +1289,19 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <artifactId>infinispan-core</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.picketlink.idm.testsuite</groupId>
+        <artifactId>common</artifactId>
+        <version>${org.picketlink.idm.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.picketlink.idm.testsuite</groupId>
+        <artifactId>common</artifactId>
+        <version>${org.picketlink.idm.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>


### PR DESCRIPTION
* Upgrade Hibernate library to version 5.6
* Delete forked library definition picketlink-idm-hibernate
* Delete banned dependency brought by Hibernate 5.6
* Delete useless Hibernate library dependency