### PR TITLE
Task-58297: Move RemoteSigningKeyResolver from mfa-oidc to gatein-portal (#88)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
     <javax.xml.stream.stax-api.version>1.0-2</javax.xml.stream.stax-api.version>
     <javax.websocket-api.version>1.1</javax.websocket-api.version>
+    <javax.json.api.version>1.1</javax.json.api.version>
     <!-- 1.1.3 used by jdom has some wrong dependencies -->
     <jaxen.version>1.1.6</jaxen.version>
     <jgroups.version>3.6.13.Final</jgroups.version>
@@ -542,6 +543,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>${version.jaxb}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.json</groupId>
+        <artifactId>javax.json-api</artifactId>
+        <version>${javax.json.api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>


### PR DESCRIPTION

when i moved class SigningKeyResolver in gatein-portal  javax.json-api are not declared 
so i fix by declared the pack