### PR TITLE
Embed Juzu Version to use latest stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- The library must follow the plugin version -->
     <org.jibx.version>${version.jibx.plugin}</org.jibx.version>
     <org.json.version>20070829</org.json.version>
-    <org.juzu.version>1.2.x-SNAPSHOT</org.juzu.version>
+    <org.juzu.version>1.2.0</org.juzu.version>
     <org.less4j.version>1.17.2</org.less4j.version>
     <org.liquibase.version>4.9.1</org.liquibase.version>
     <org.mockito.version>3.11.1</org.mockito.version>


### PR DESCRIPTION
Prior to this change, juzu version was referencing a SNAPSHOT.
This change will embed juzu version to use the latest stable that is used since few years (which is 1.2.0).