### PR TITLE
fix: Fix issue with lombok when compiling using JDK 17 - Meeds-io/meeds#304

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.codehaus.jackson.core.asl>1.9.13</version.codehaus.jackson.core.asl>
     <version.reflext>1.1.0</version.reflext>
     <version.scribejava>6.9.0</version.scribejava>
-    <org.lombok.version>1.18.2</org.lombok.version>
+    <org.lombok.version>1.18.24</org.lombok.version>
     <org.gatein.api.version>1.0.1.Final</org.gatein.api.version>
     <org.gatein.mop.version>1.3.2.Final</org.gatein.mop.version>
     <org.gatein.mgmt.version>2.1.0.Final</org.gatein.mgmt.version>


### PR DESCRIPTION
When compiling a project using current version of `lombok`, an error happens :  `
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project wallet-api: Fatal error compiling: java.lang.ExceptionInInitializerError: Unable to make field private com.sun.tools.javac.processing.JavacProcessingEnvironment$DiscoveredProcessors com.sun.tools.javac.processing.JavacProcessingEnvironment.discoveredProcs accessible: module jdk.compiler does not "opens com.sun.tools.javac.processing" to unnamed module @15c25cb6 -> [Help 1] `
This change will fix it by upgrading `lombok` to latest stable version `1.18.24`