### PR TITLE
fix: Fix Missing Mockito Dependency artifact - MEED-1304 - Meeds-io/MIPs#29

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1238,7 +1238,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
+        <artifactId>mockito-inline</artifactId>
         <version>${org.mockito.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Prior to this change, the artifact identifier mockito-all was used instead of mockito-inline. In fact, the mockito-all was removed since 2015, version 2.0.