### PR TITLE
fix: Upgrade Tomcat and Spring Maintenance versions - MEED-7171 - Meeds-io/meeds#2249

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <!-- **************************************** -->
     <!-- Dependencies Versions                    -->
     <!-- **************************************** -->
-    <spring-boot-dependencies.version>3.2.5</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>3.2.7</spring-boot-dependencies.version>
     <com.google.javascript.version>v20220104</com.google.javascript.version>
     <com.googlecode.json-simple.version>1.1.1</com.googlecode.json-simple.version>
     <com.googlecode.owasp-java-html-sanitizer.version>20220608.1</com.googlecode.owasp-java-html-sanitizer.version>
@@ -144,7 +144,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.resolver>2.2.5</version.shrinkwrap.resolver>
     <!-- Servers -->
-    <tomcat.version>10.1.17</tomcat.version>
+    <tomcat.version>10.1.25</tomcat.version>
     <org.graalvm.js.version>22.0.0</org.graalvm.js.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
Prior to this change, the JSESSIONIDSSO cookie is sometime not recreated when the JSESSIONID cookie is renewed due to session timeout. This change will upgrade to latest Tomcat 10.1 maintenance version in order to benefit from fixes made which includes the fix of such behavior.