### PR TITLE
feat: Cleanup ISPN and useless third party libraries - MEED-7742 - Meeds-io/meeds#2537

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <com.googlecode.json-simple.version>1.1.1</com.googlecode.json-simple.version>
     <com.googlecode.owasp-java-html-sanitizer.version>20220608.1</com.googlecode.owasp-java-html-sanitizer.version>
     <com.sun.mail.version>1.6.2</com.sun.mail.version>
-    <legacy.commons-chain.version>1.3.0</legacy.commons-chain.version>
     <commons-collections.version>3.2.2</commons-collections.version>
     <commons-fileupload2.version>2.0.0-M1</commons-fileupload2.version>
     <commons-httpclient.version>3.1</commons-httpclient.version>
@@ -69,13 +68,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <javax.portlet.version>2.0</javax.portlet.version>
     <jakarta.servlet.version>6.0.0</jakarta.servlet.version>
     <jakarta.servlet.jsp.version>3.1.1</jakarta.servlet.jsp.version>
-    <javax.transaction.version>1.3</javax.transaction.version>
     <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
     <!-- Overridden from Spring due to bug Meeds-io/meeds#1582 -->
     <liquibase.version>4.25.1</liquibase.version>
     <liquibase-slf4j.version>5.0.0</liquibase-slf4j.version>
     <!-- 1.1.3 used by jdom has some wrong dependencies -->
-    <jgroups.version>3.6.13.Final</jgroups.version>
     <jsoup.version>1.15.3</jsoup.version>
     <org.apache.poi.version>5.2.5</org.apache.poi.version>
     <org.bouncycastle.version>1.70</org.bouncycastle.version>
@@ -89,12 +86,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <jetty.version>11.0.18</jetty.version>
 
     <org.imgscalr.version>4.2</org.imgscalr.version>
-    <org.infinispan.version>8.2.6.Final</org.infinispan.version>
-    <!-- Override dependency inherited from infinispan to make the cluster works on JDK 11 -->
-    <org.jboss.marshalling.version>2.0.10.Final</org.jboss.marshalling.version>
-    <org.jboss.jbossts.version>4.16.6.Final</org.jboss.jbossts.version>
     <org.javassist.version>3.30.1-GA</org.javassist.version>
-    <org.jboss.jboss-logging.version>3.3.0.Final</org.jboss.jboss-logging.version>
     <org.jboss.dmr.version>1.1.1.Final</org.jboss.dmr.version>
     <!-- The library must follow the plugin version -->
     <org.jibx.version>${version.jibx.plugin}</org.jibx.version>
@@ -114,12 +106,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.jregex>1.2_01</version.jregex>
     <version.japex>1.2.3</version.japex>
     <version.cdi.spec>2.0.SP1</version.cdi.spec>
-    <version.org.antlr>3.5.2</version.org.antlr>
-    <version.antlr>2.7.6rc1</version.antlr>
-    <version.xml-apis>1.4.01</version.xml-apis>
     <version.apache.commons-beanutils>1.9.4</version.apache.commons-beanutils>
     <version.apache.commons-dbcp>1.4</version.apache.commons-dbcp>
-    <version.apache.commons-digester>2.1</version.apache.commons-digester>
     <version.twitter4j>3.0.5</version.twitter4j>
     <version.restfb>1.6.12</version.restfb>
     <version.google.oauth.client>1.33.3</version.google.oauth.client>
@@ -135,9 +123,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.gatein.naming.version>1.1.1.Final</org.gatein.naming.version>
     <org.gatein.common.version>2.2.2.Final</org.gatein.common.version>
     <com.jhlabs.filters.version>2.0.235-1</com.jhlabs.filters.version>
-    <!-- 3rd party deprecated libraries versions -->
-    <transactions-jta.version>3.8.0</transactions-jta.version>
-    <com.experlog.xapool.version>1.5.0</com.experlog.xapool.version>
     <!-- For testing only -->
     <version.arquillian>1.7.1.Final</version.arquillian>
     <version.arquillian.tomcat>1.2.0.Final</version.arquillian.tomcat>
@@ -202,11 +187,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <version>${version.apache.commons-beanutils}</version>
       </dependency>
       <dependency>
-        <groupId>io.github.weblegacy</groupId>
-        <artifactId>commons-chain-web-jakarta-servlet</artifactId>
-        <version>${legacy.commons-chain.version}</version>
-      </dependency>
-      <dependency>
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
         <version>${commons-collections.version}</version>
@@ -242,21 +222,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>commons-pool</groupId>
-            <artifactId>commons-pool</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${commons-io.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-digester</groupId>
-        <artifactId>commons-digester</artifactId>
-        <version>${version.apache.commons-digester}</version>
       </dependency>
       <dependency>
         <groupId>ecs</groupId>
@@ -330,12 +301,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <groupId>javax.resource</groupId>
         <artifactId>javax.resource-api</artifactId>
         <version>${version.javax.resource}</version>
-      </dependency>
-      <!-- TODO: Artifacts to move to Jakarta EE -->
-      <dependency>
-        <groupId>javax.transaction</groupId>
-        <artifactId>javax.transaction-api</artifactId>
-        <version>${javax.transaction.version}</version>
       </dependency>
       <!-- TODO: Artifacts to move to Jakarta EE -->
       <dependency>
@@ -531,67 +496,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <artifactId>imgscalr-lib</artifactId>
         <version>${org.imgscalr.version}</version>
       </dependency>
-      <!-- Override dependency inherited from infinispan to make the cluster works on JDK 11 -->
-      <dependency>
-        <groupId>org.jboss.marshalling</groupId>
-        <artifactId>jboss-marshalling-osgi</artifactId>
-        <version>${org.jboss.marshalling.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-core</artifactId>
-        <version>${org.infinispan.version}</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-cachestore-jdbc</artifactId>
-        <version>${org.infinispan.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.infinispan</groupId>
-        <artifactId>infinispan-commons</artifactId>
-        <version>${org.infinispan.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
         <version>${org.javassist.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.jboss.logging</groupId>
-        <artifactId>jboss-logging</artifactId>
-        <version>${org.jboss.jboss-logging.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jboss.jbossts</groupId>
-        <artifactId>jbossjta</artifactId>
-        <version>${org.jboss.jbossts.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.jgroups</groupId>
-        <artifactId>jgroups</artifactId>
-        <version>${jgroups.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.jibx</groupId>
         <artifactId>jibx-run</artifactId>
         <version>${org.jibx.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr-runtime</artifactId>
-        <version>${version.org.antlr}</version>
-      </dependency>
-      <dependency>
-        <groupId>antlr</groupId>
-        <artifactId>antlr</artifactId>
-        <version>${version.antlr}</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>
@@ -682,12 +595,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           </exclusion>
         </exclusions>
       </dependency>
-      <!-- dependency is here because Apache POI needs log4j-api.-->
       <dependency>
         <groupId>org.staxnav</groupId>
         <artifactId>staxnav.core</artifactId>
         <version>${org.staxnav.version}</version>
       </dependency>
+      <!-- Used by Notes for Diff Engine -->
       <dependency>
         <groupId>org.suigeneris</groupId>
         <artifactId>jrcs.diff</artifactId>
@@ -735,12 +648,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <version>${org.web3j.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>${version.xml-apis}</version>
-        <scope>test</scope>
-      </dependency>
       <!-- OAuth integration with Twitter -->
       <dependency>
         <groupId>org.twitter4j</groupId>
@@ -784,6 +691,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <artifactId>restfb</artifactId>
         <version>${version.restfb}</version>
       </dependency>
+      <!-- Used by Web Controller for Test purpose -->
       <dependency>
         <groupId>net.sourceforge.jregex</groupId>
         <artifactId>jregex</artifactId>
@@ -924,16 +832,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <scope>test</scope>
       </dependency>
       <!-- Third party dependencies used by deprecated services  -->
-      <dependency>
-        <groupId>com.experlog</groupId>
-        <artifactId>xapool</artifactId>
-        <version>${com.experlog.xapool.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.atomikos</groupId>
-        <artifactId>transactions-jta</artifactId>
-        <version>${transactions-jta.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.graalvm.js</groupId>
         <artifactId>js</artifactId>


### PR DESCRIPTION
This change will remove useless dependencies to ISPN8 and other useless third party libraries.

Resolves https://github.com/Meeds-io/meeds/issues/2537