### PR TITLE
fix: update protobuf dependency version - MEED-9912 - meeds-io/meeds#3808

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <org.jibx.version>${version.jibx.plugin}</org.jibx.version>
     <org.json.version>20231013</org.json.version>
     <org.less4j.version>1.17.2</org.less4j.version>
+    <com.google.protobuf.version>4.33.0</com.google.protobuf.version>
     <org.mockito.version>3.11.1</org.mockito.version>
     <org.picketlink.idm.version>1.4.6.Final</org.picketlink.idm.version>
     <org.staxnav.version>0.9.8</org.staxnav.version>
@@ -510,6 +511,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <groupId>com.google.code.gson</groupId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <!-- protobuf is a dependency of com.github.sommeri:less4j-->
+      <!-- the version coming with last version of less4j (1.17.2) is protobuf-java:2.5.0 -->
+      <!-- protobuf-java:2.5.0 is vulnerable to CVE-2021-22569 and CVE-2024-7254 -->
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java</artifactId>
+        <version>${com.google.protobuf.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
This commit ensure to update the protobuf version dependency Protobuf is a transitive dependency coming from com.github.sommeri:less4j, and vulnerable to CVEs (CVE-2021-22569 and CVE-2024-7254). There is no recent version of less4j to update protobuf, so this commit ensure to override the version of protobuf by using the last existing one.

Resolves meeds-io/meeds#3808

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
