### PR TITLE
TASK-82937: Bump tomcat version from 9.0.99 to 9.0.110

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap.resolver>2.2.5</version.shrinkwrap.resolver>
     <!-- Servers -->
-    <org.apache.tomcat.version>9.0.99</org.apache.tomcat.version>
+    <org.apache.tomcat.version>9.0.110</org.apache.tomcat.version>
     <com.fasterxml.jackson.version>2.13.5</com.fasterxml.jackson.version>
     <org.graalvm.js.version>22.0.0</org.graalvm.js.version>
   </properties>


### PR DESCRIPTION
The changes of the tomcat version aims to include the fixes of cve mentionned here: https://www.cvedetails.com/vulnerability-list/vendor_id-45/product_id-887/version_id-1898393/Apache-Tomcat-9.0.99.html
